### PR TITLE
Fix UTF8 encoding being used instead of Shift-JIS

### DIFF
--- a/CriFsV2Lib/Structs/CriTableMetadata.cs
+++ b/CriFsV2Lib/Structs/CriTableMetadata.cs
@@ -76,7 +76,7 @@ public unsafe ref struct CriTableMetadata
     /// Gets the encoding for this file.
     /// </summary>
     /// <param name="header">Header of the file.</param>
-    public Encoding GetEncoding(byte* header) => *(header + 0x9) == 1 ? Shift_JIS : Encoding.UTF8;
+    public Encoding GetEncoding(byte* header) => *(header + 0x9) == 0 ? Shift_JIS : Encoding.UTF8;
 
     /// <summary>
     /// Returns the pointer to the first column.


### PR DESCRIPTION
According to [TGE's template](https://github.com/tge-was-taken/010-Editor-Templates/blob/c74cbd39b67829c37d3e781a23f874db7a6028e1/releases/cri_archives/cri_archives_rel_1.bt#L18C35-L18C35) Shift-JIS is 0 and UTF-8 is 1, this was swapped around when getting the encoding.